### PR TITLE
fix(controller): update scan logic to handle file versioning and disp…

### DIFF
--- a/src/DirectoryChangesTracker/Models/DirectorySnapshot.cs
+++ b/src/DirectoryChangesTracker/Models/DirectorySnapshot.cs
@@ -17,7 +17,7 @@ namespace DirectoryChangesTracker.Models
 		/// <summary>
 		/// Date and time when this directory was scanned for the first time.
 		/// </summary>
-		public DateTime FirstListing { get; set; }
+		public DateTime FirstListing { get; set; } = DateTime.Now;
 
 		/// <summary>
 		/// Date and time when this directory was scanned most recently.

--- a/src/DirectoryChangesTracker/Models/FileSnapshot.cs
+++ b/src/DirectoryChangesTracker/Models/FileSnapshot.cs
@@ -23,6 +23,6 @@
 		/// <summary>
 		/// Version number that increments each time the file is modified.
 		/// </summary>
-		public int Version { get; set; }
+		public int Version { get; set; } = 1;
 	}
 }

--- a/src/DirectoryChangesTracker/Services/DirectorySnapshotComparer.cs
+++ b/src/DirectoryChangesTracker/Services/DirectorySnapshotComparer.cs
@@ -69,17 +69,39 @@ namespace DirectoryChangesTracker.Services
 				.Where(nf => oldFiles.Any(of => of.LocalPath == nf.LocalPath && of.Md5Hash != nf.Md5Hash))
 				.ToHashSet();
 
-			// set the version 1 for the new created files
-			foreach (var newFile in newCreatedFiles)
-				newFile.Version = 1;
-
-			// increment the version for the modified files
-			foreach (var modifiedFile in modifiedFiles)
-				modifiedFile.Version += 1;
+			IncrementAndSetLastFileVersion(modifiedFiles, oldFiles, newFiles);
 
 			scannedDirectoryResult.NewCreatedFiles = newCreatedFiles;
 			scannedDirectoryResult.ModifiedFiles = modifiedFiles;
 			scannedDirectoryResult.DeletedFiles = deletedFiles;
+		}
+
+		/// <summary>
+		/// Increments the version number of modified files by comparing them with their previous versions.
+		/// </summary>
+		/// <param name="modifiedFiles">The set of files that have been detected as modified.</param>
+		/// <param name="oldFiles">The set of file snapshots from the previous scan.</param>
+		/// <param name="newFiles">The set of file snapshots from the current scan.</param>
+		/// <remarks>
+		/// For each file in <paramref name="newFiles"/> that is also in <paramref name="modifiedFiles"/> 
+		/// and exists in <paramref name="oldFiles"/>, this method sets its version to the previous version + 1.
+		/// </remarks>
+		private void IncrementAndSetLastFileVersion(HashSet<FileSnapshot> modifiedFiles, HashSet<FileSnapshot> oldFiles, HashSet<FileSnapshot> newFiles)
+		{
+			if (oldFiles == null || newFiles == null || !oldFiles.Any() || !newFiles.Any())
+				return;
+
+			foreach (FileSnapshot newFile in newFiles)
+			{
+				if (oldFiles.Any(of => of.LocalPath == newFile.LocalPath))
+				{
+					int lastVersion = oldFiles.First(of => of.LocalPath == newFile.LocalPath).Version;
+					newFile.Version = lastVersion;
+
+					if (modifiedFiles.Any(mf => mf.LocalPath == newFile.LocalPath))
+						newFile.Version++;
+				}
+			}
 		}
 
 		/// <summary>

--- a/src/DirectoryChangesTracker/Validators/DirectoryValidator.cs
+++ b/src/DirectoryChangesTracker/Validators/DirectoryValidator.cs
@@ -21,8 +21,8 @@ namespace DirectoryChangesTracker.Validators
 			if (string.IsNullOrEmpty(localDirectoryPath))
 				return Result.Failure($"The provided folder path '{localDirectoryPath}' is null or empty");
 
-			if (!Directory.Exists(localDirectoryPath))
-				return Result.Failure($"The provided directory path '{localDirectoryPath}' doesn't exist");
+			//if (!Directory.Exists(localDirectoryPath))
+			//	return Result.Failure($"The provided directory path '{localDirectoryPath}' doesn't exist");
 
 			return Result.Success();
 		}

--- a/src/DirectoryChangesTracker/Validators/FileValidator.cs
+++ b/src/DirectoryChangesTracker/Validators/FileValidator.cs
@@ -45,7 +45,7 @@ namespace DirectoryChangesTracker.Validators
 			catch (Exception ex)
 			{
 				//TODO: log the exception
-				return Result<FileSnapshot>.Failure($"Exception caught during reading the The file on the provided file path '{fileLocalPath}'");
+				return Result<FileSnapshot>.Failure($"Exception caught during reading the file on the provided file path '{fileLocalPath}'");
 			}
 		}
 	}

--- a/src/DirectoryChangesTracker/Views/ScanDirectory/ScanDirectory.cshtml
+++ b/src/DirectoryChangesTracker/Views/ScanDirectory/ScanDirectory.cshtml
@@ -37,6 +37,14 @@ else
 			<strong>@Model.DirectorySnapshot.LocalPath</strong>
 		</div>
 	}
+	else if (Model.IsNew)
+	{
+		<div class="alert alert-success">
+			Newly created directory for path:
+			<strong>@Model.DirectorySnapshot.LocalPath</strong>
+		</div>
+	}
+
 	else
 	{
 		@if (Model.NewCreatedFiles.Any())
@@ -93,6 +101,23 @@ else
 				}
 			</ul>
 		}
+	}
+
+	@if (Model.DirectorySnapshot.Files.Any())
+	{
+		<h4>
+			<a class="text-decoration-none" data-bs-toggle="collapse" href="#newFilesCollapse" role="button" aria-expanded="false" aria-controls="newFilesCollapse">
+				🟢 Current files count: @Model.DirectorySnapshot.Files.Count (click to see the list)
+			</a>
+		</h4>
+		<div class="collapse mb-3" id="newFilesCollapse">
+			<ul class="list-group">
+				@foreach (FileSnapshot file in Model.DirectorySnapshot.Files)
+				{
+					<li class="list-group-item text-break">@file.LocalPath, Version: @file.Version</li>
+				}
+			</ul>
+		</div>
 	}
 }
 


### PR DESCRIPTION
…lay full scan results

- Updated ScanDirectoryController to delete saved results for non-existing directories
- Moved directory existence validation from DirectoryValidator to controller
- Set default value for FileSnapshot.Version
- Set default value for DirectorySnapshot.FirstListing
- Updated DirectorySnapshotComparer to increment versions of modified files
- Updated ScanDirectory view to show newly created directories and file list with versions
- Added explanatory comments